### PR TITLE
Base DPC++ docker container on the image from intel/llvm.

### DIFF
--- a/docker/dpcpp/Dockerfile
+++ b/docker/dpcpp/Dockerfile
@@ -1,24 +1,4 @@
-# DPC++ version (git revision) to install
-ARG IMPL_VERSION
-
-FROM khronosgroup/sycl-cts-ci:common
-
-ARG IMPL_VERSION
-RUN test -n "$IMPL_VERSION" || ( echo "Error: IMPL_VERSION is not set"; exit 1 )
-
-RUN git clone https://github.com/intel/llvm.git \
-      --branch=sycl --single-branch --shallow-since=2021-09-01 \
-      --recurse-submodules /tmp/dpcpp && \
-    cd /tmp/dpcpp && \
-    git checkout $IMPL_VERSION && \
-    python3 /tmp/dpcpp/buildbot/configure.py \
-      --src-dir=/tmp/dpcpp \
-      --obj-dir=/tmp/build \
-      --build-type=Release \
-      --cmake-opt=-DCMAKE_INSTALL_PREFIX=/sycl && \
-    python3 /tmp/dpcpp/buildbot/compile.py \
-      --src-dir=/tmp/dpcpp \
-      --obj-dir=/tmp/build && \
-    rm -rf /tmp/dpcpp /tmp/build
+# Go to https://github.com/intel/llvm/pkgs/container/llvm%2Fsycl_ubuntu2204_nightly for the latest docker image tag
+FROM ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers-c9219ce7232da9bc10d50dff8a1858540b292df5
 
 COPY configure.sh /scripts/

--- a/docker/dpcpp/configure.sh
+++ b/docker/dpcpp/configure.sh
@@ -5,8 +5,8 @@ set -o errexit -o pipefail -o noclobber -o nounset
 cmake . -G Ninja -B build \
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
     -DSYCL_IMPLEMENTATION=DPCPP \
-    -DDPCPP_INSTALL_DIR=/sycl \
-    -DCMAKE_CXX_COMPILER=/sycl/bin/clang++ \
+    -DDPCPP_INSTALL_DIR=/opt/sycl \
+    -DCMAKE_CXX_COMPILER=/opt/sycl/bin/clang++ \
     -DCMAKE_BUILD_TYPE=Release \
     -DSYCL_CTS_ENABLE_FULL_CONFORMANCE=0 \
     -DSYCL_CTS_ENABLE_DEPRECATED_FEATURES_TESTS=1 \


### PR DESCRIPTION
intel/llvm project provides daily built docker images with pre-built DPC++ compiler. Using this image saves us time to build the compiler from sources.